### PR TITLE
fixed breaking position calculation issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # foundry-vtt-loadouts
 
-### 2.1.6a
+### 2.1.7a
 - Support for multiple Loadouts scenes
 - BREAKING: all flag references changed from `loadout` to `loadouts`
 

--- a/module.json
+++ b/module.json
@@ -9,7 +9,7 @@
       "url": "https://www.buymeacoffee.com/draphtx"
     }
   ],
-  "version": "2.1.6",
+  "version": "2.1.7",
   "minimumCoreVersion": "10.283",
   "scripts": [
     "scripts/loadoutsHooks.js"

--- a/scripts/loadoutsHooks.js
+++ b/scripts/loadoutsHooks.js
@@ -133,14 +133,14 @@ function processTilePositions(validTiles, itemOrientation){
                 // If the blockingToken is >= the new item, the item should use the filter but with Math.max
             if(blockingToken.width >= itemSizeL * loadoutsTile.parent.grid.size || blockingToken.height > itemSizeH * loadoutsTile.parent.grid.size){
                 itemPositions = itemPositions.filter(p => 
-                    p.x1 >= Math.max(blockingToken.x + blockingToken.width, blockingToken.x + itemSizeL * loadoutsTile.parent.grid.size) || blockingToken.x >= p.x2 || 
-                    p.y1 >= Math.max(blockingToken.y + blockingToken.height, blockingToken.y + itemSizeH * loadoutsTile.parent.grid.size) || blockingToken.y >= p.y2
+                    p.x1 >= Math.max(blockingToken.x + blockingToken.width * loadoutsTile.parent.grid.size, blockingToken.x + itemSizeL * loadoutsTile.parent.grid.size) || blockingToken.x >= p.x2 || 
+                    p.y1 >= Math.max(blockingToken.y + blockingToken.height * loadoutsTile.parent.grid.size, blockingToken.y + itemSizeH * loadoutsTile.parent.grid.size) || blockingToken.y >= p.y2
                     )
             // If the blockingToken is < the new item, the item should use the filter but with Math.min
             } else {
                 itemPositions = itemPositions.filter(p => 
-                    p.x1 >= Math.min(blockingToken.x + blockingToken.width, blockingToken.x + itemSizeL * loadoutsTile.parent.grid.size) || blockingToken.x >= p.x2 || 
-                    p.y1 >= Math.min(blockingToken.y + blockingToken.height, blockingToken.y + itemSizeH * loadoutsTile.parent.grid.size) || blockingToken.y >= p.y2
+                    p.x1 >= Math.min(blockingToken.x + blockingToken.width * loadoutsTile.parent.grid.size, blockingToken.x + itemSizeL * loadoutsTile.parent.grid.size) || blockingToken.x >= p.x2 || 
+                    p.y1 >= Math.min(blockingToken.y + blockingToken.height * loadoutsTile.parent.grid.size, blockingToken.y + itemSizeH * loadoutsTile.parent.grid.size) || blockingToken.y >= p.y2
                     )
             }
         }


### PR DESCRIPTION
When refactoring for multiscene support, the blockingTokens algo broke due to the calculations being run against tokenDocuments rather than actual tokens.