### PR TITLE
Locked token rotation; fixed config script call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # foundry-vtt-loadouts
 
-### 2.2.1a
+### 2.2.2a
 - Dynamic token pre-release
 - Lots of flag and minor name revisions that will break backwards compatibility
 

--- a/module.json
+++ b/module.json
@@ -10,7 +10,7 @@
       "url": "https://www.buymeacoffee.com/draphtx"
     }
   ],
-  "version": "2.2.1",
+  "version": "2.2.2",
   "minimumCoreVersion": "10.283",
   "relationships": {
     "systems": [
@@ -21,7 +21,8 @@
     ]
   },
   "scripts": [
-    "scripts/loadoutsHooks.js"
+    "scripts/loadoutsHooks.js",
+    "scripts/config.js"
   ],
   "languages": [
     {

--- a/scripts/loadoutsHooks.js
+++ b/scripts/loadoutsHooks.js
@@ -223,7 +223,8 @@ async function placeItemActor(selectedTile, validPositions, itemOrientation, ite
         height: itemOrientation.size_y,
         x: validPositions[0].x1,                                            // First-available position's x coord
         y: validPositions[0].y1,                                            // First-available position's y coord
-        rotation: itemOrientation.rotation                                  // Token's rotation
+        rotation: itemOrientation.rotation,                                 // Token's rotation
+        lockRotation: true
     }
 
     // Override some positional settings if rotated


### PR DESCRIPTION
Had some issues with 2.2.1 release that made sense to quickly fix